### PR TITLE
[ISSUE-948][REFACTOR] Replace userResourceConsumption of WorkerInfo with empty value for unnecessary ControlMessages

### DIFF
--- a/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/protocol/message/ControlMessages.scala
@@ -583,7 +583,9 @@ object ControlMessages extends Logging {
 
     case GetBlacklist(localBlacklist) =>
       val payload = PbGetBlacklist.newBuilder()
-        .addAllLocalBlackList(localBlacklist.asScala.map(PbSerDeUtils.toPbWorkerInfo)
+        .addAllLocalBlackList(localBlacklist.asScala.map { workerInfo =>
+          PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
+        }
           .toList.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.GET_BLACKLIST, payload)
@@ -591,9 +593,13 @@ object ControlMessages extends Logging {
     case GetBlacklistResponse(statusCode, blacklist, unknownWorkers) =>
       val builder = PbGetBlacklistResponse.newBuilder()
         .setStatus(statusCode.getValue)
-      builder.addAllBlacklist(blacklist.asScala.map(PbSerDeUtils.toPbWorkerInfo).toList.asJava)
-      builder.addAllUnknownWorkers(
-        unknownWorkers.asScala.map(PbSerDeUtils.toPbWorkerInfo).toList.asJava)
+      builder.addAllBlacklist(blacklist.asScala.map { workerInfo =>
+        PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
+      }
+        .toList.asJava)
+      builder.addAllUnknownWorkers(unknownWorkers.asScala.map { workerInfo =>
+        PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
+      }.toList.asJava)
       val payload = builder.build().toByteArray
       new TransportMessage(MessageType.GET_BLACKLIST_RESPONSE, payload)
 
@@ -612,7 +618,10 @@ object ControlMessages extends Logging {
 
     case ReportWorkerUnavailable(failed, requestId) =>
       val payload = PbReportWorkerUnavailable.newBuilder()
-        .addAllUnavailable(failed.asScala.map(PbSerDeUtils.toPbWorkerInfo(_)).toList.asJava)
+        .addAllUnavailable(failed.asScala.map { workerInfo =>
+          PbSerDeUtils.toPbWorkerInfo(workerInfo, true)
+        }
+          .toList.asJava)
         .setRequestId(requestId).build().toByteArray
       new TransportMessage(MessageType.REPORT_WORKER_FAILURE, payload)
 
@@ -724,7 +733,10 @@ object ControlMessages extends Logging {
     case GetWorkerInfosResponse(status, workerInfos @ _*) =>
       val payload = PbGetWorkerInfosResponse.newBuilder()
         .setStatus(status.getValue)
-        .addAllWorkerInfos(workerInfos.map(PbSerDeUtils.toPbWorkerInfo(_)).toList.asJava)
+        .addAllWorkerInfos(workerInfos.map { workerInfo =>
+          PbSerDeUtils.toPbWorkerInfo(workerInfo, false)
+        }
+          .toList.asJava)
         .build().toByteArray
       new TransportMessage(MessageType.GET_WORKER_INFO_RESPONSE, payload)
 

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -190,25 +190,22 @@ object PbSerDeUtils {
 
   def toPbWorkerInfo(
       workerInfo: WorkerInfo,
-      setUserResourceConsumptionEmpty: Boolean): PbWorkerInfo = {
+      eliminateUserResourceConsumption: Boolean): PbWorkerInfo = {
     val diskInfos = workerInfo.diskInfos.values
     val pbDiskInfos = new util.ArrayList[PbDiskInfo]()
     diskInfos.asScala.foreach(k => pbDiskInfos.add(PbSerDeUtils.toPbDiskInfo(k)))
-    PbWorkerInfo.newBuilder
+    val builder = PbWorkerInfo.newBuilder
       .setHost(workerInfo.host)
       .setRpcPort(workerInfo.rpcPort)
       .setFetchPort(workerInfo.fetchPort)
       .setPushPort(workerInfo.pushPort)
       .setReplicatePort(workerInfo.replicatePort)
       .addAllDisks(pbDiskInfos)
-      .putAllUserResourceConsumption {
-        if (setUserResourceConsumptionEmpty) {
-          new util.HashMap[String, PbResourceConsumption]()
-        } else {
-          PbSerDeUtils.toPbUserResourceConsumption(workerInfo.userResourceConsumption)
-        }
-      }
-      .build
+    if (!eliminateUserResourceConsumption) {
+      builder.putAllUserResourceConsumption(
+        PbSerDeUtils.toPbUserResourceConsumption(workerInfo.userResourceConsumption))
+    }
+    builder.build
   }
 
   def fromPbPartitionLocation(pbLoc: PbPartitionLocation): PartitionLocation = {

--- a/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/util/PbSerDeUtils.scala
@@ -188,7 +188,9 @@ object PbSerDeUtils {
       null)
   }
 
-  def toPbWorkerInfo(workerInfo: WorkerInfo): PbWorkerInfo = {
+  def toPbWorkerInfo(
+      workerInfo: WorkerInfo,
+      setUserResourceConsumptionEmpty: Boolean): PbWorkerInfo = {
     val diskInfos = workerInfo.diskInfos.values
     val pbDiskInfos = new util.ArrayList[PbDiskInfo]()
     diskInfos.asScala.foreach(k => pbDiskInfos.add(PbSerDeUtils.toPbDiskInfo(k)))
@@ -199,8 +201,13 @@ object PbSerDeUtils {
       .setPushPort(workerInfo.pushPort)
       .setReplicatePort(workerInfo.replicatePort)
       .addAllDisks(pbDiskInfos)
-      .putAllUserResourceConsumption(
-        PbSerDeUtils.toPbUserResourceConsumption(workerInfo.userResourceConsumption))
+      .putAllUserResourceConsumption {
+        if (setUserResourceConsumptionEmpty) {
+          new util.HashMap[String, PbResourceConsumption]()
+        } else {
+          PbSerDeUtils.toPbUserResourceConsumption(workerInfo.userResourceConsumption)
+        }
+      }
       .build
   }
 

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -161,10 +161,15 @@ class PbSerDeUtilsTest extends RssFunSuite {
   }
 
   test("fromAndToPbWorkerInfo") {
-    val pbWorkerInfo = PbSerDeUtils.toPbWorkerInfo(workerInfo1)
+    val pbWorkerInfo = PbSerDeUtils.toPbWorkerInfo(workerInfo1, false)
+    val pbWorkerInfoWithEmptyResource = PbSerDeUtils.toPbWorkerInfo(workerInfo1, true)
     val restoredWorkerInfo = PbSerDeUtils.fromPbWorkerInfo(pbWorkerInfo)
+    val restoredWorkerInfoWithEmptyResource = PbSerDeUtils.fromPbWorkerInfo(pbWorkerInfoWithEmptyResource)
 
     assert(restoredWorkerInfo.equals(workerInfo1))
+    assert(restoredWorkerInfoWithEmptyResource.userResourceConsumption.equals(new util.HashMap[
+      UserIdentifier,
+      ResourceConsumption]()))
   }
 
   test("fromAndToPbPartitionLocation") {

--- a/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
+++ b/common/src/test/scala/org/apache/celeborn/common/util/PbSerDeUtilsTest.scala
@@ -164,7 +164,8 @@ class PbSerDeUtilsTest extends RssFunSuite {
     val pbWorkerInfo = PbSerDeUtils.toPbWorkerInfo(workerInfo1, false)
     val pbWorkerInfoWithEmptyResource = PbSerDeUtils.toPbWorkerInfo(workerInfo1, true)
     val restoredWorkerInfo = PbSerDeUtils.fromPbWorkerInfo(pbWorkerInfo)
-    val restoredWorkerInfoWithEmptyResource = PbSerDeUtils.fromPbWorkerInfo(pbWorkerInfoWithEmptyResource)
+    val restoredWorkerInfoWithEmptyResource =
+      PbSerDeUtils.fromPbWorkerInfo(pbWorkerInfoWithEmptyResource)
 
     assert(restoredWorkerInfo.equals(workerInfo1))
     assert(restoredWorkerInfoWithEmptyResource.userResourceConsumption.equals(new util.HashMap[


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace userResourceConsumption of WorkerInfo with empty value for unnecessary ControlMessages

### Why are the changes needed?
Because in some rpc message the userResourceConsumption inside WorkerInfo is redundant, we won't use them in late logic, so we can replace it with empty map to reduce the RPC pressure.

### What are the items that need reviewer attention?
Could we directly use null as the empty value instead of empty hashmap?

### Related issues.
closed #948 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
